### PR TITLE
Updating octree rather than rebuilding on each frame

### DIFF
--- a/Assets/Scenes/3D/3D Brute Force.unity
+++ b/Assets/Scenes/3D/3D Brute Force.unity
@@ -317,6 +317,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   MoveSpeed: 20
   RotateSpeed: 100
+  MovementRemaining: 0
 --- !u!1 &113888554
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/3D/3D Explosion.unity
+++ b/Assets/Scenes/3D/3D Explosion.unity
@@ -1,0 +1,1077 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &48431402
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 48431403}
+  - component: {fileID: 48431406}
+  - component: {fileID: 48431405}
+  - component: {fileID: 48431404}
+  m_Layer: 0
+  m_Name: Wall
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &48431403
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 48431402}
+  m_LocalRotation: {x: 0.5, y: 0.5, z: -0.5, w: -0.5}
+  m_LocalPosition: {x: 0, y: 0, z: 50}
+  m_LocalScale: {x: 10, y: 10, z: 10}
+  m_Children: []
+  m_Father: {fileID: 1951022366}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 270, z: 90}
+--- !u!64 &48431404
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 48431402}
+  m_Material: {fileID: 13400000, guid: 8a710917d45110747b42a848bb68ad96, type: 2}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &48431405
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 48431402}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 70a4e4c187842a648a6caf214821693a, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &48431406
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 48431402}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &94087458
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 94087461}
+  - component: {fileID: 94087460}
+  - component: {fileID: 94087459}
+  - component: {fileID: 94087462}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &94087459
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 94087458}
+  m_Enabled: 1
+--- !u!20 &94087460
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 94087458}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &94087461
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 94087458}
+  m_LocalRotation: {x: 0.3420201, y: 0, z: 0, w: 0.9396927}
+  m_LocalPosition: {x: 0, y: 80, z: -105}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 40, y: 0, z: 0}
+--- !u!114 &94087462
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 94087458}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62188cf227c1b034f8879a4123c45d65, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MoveSpeed: 20
+  RotateSpeed: 100
+  MovementRemaining: 0
+--- !u!1 &113888554
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 113888555}
+  - component: {fileID: 113888558}
+  - component: {fileID: 113888557}
+  - component: {fileID: 113888556}
+  m_Layer: 0
+  m_Name: Wall
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &113888555
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 113888554}
+  m_LocalRotation: {x: 0, y: -0, z: 0.7071068, w: -0.7071068}
+  m_LocalPosition: {x: -50, y: 0, z: 0}
+  m_LocalScale: {x: 10, y: 10, z: 10}
+  m_Children: []
+  m_Father: {fileID: 1951022366}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 270}
+--- !u!64 &113888556
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 113888554}
+  m_Material: {fileID: 13400000, guid: 8a710917d45110747b42a848bb68ad96, type: 2}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &113888557
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 113888554}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 70a4e4c187842a648a6caf214821693a, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &113888558
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 113888554}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &304001789
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 304001790}
+  - component: {fileID: 304001793}
+  - component: {fileID: 304001792}
+  - component: {fileID: 304001791}
+  m_Layer: 0
+  m_Name: Wall
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &304001790
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 304001789}
+  m_LocalRotation: {x: 0.5, y: 0.5, z: 0.5, w: 0.5}
+  m_LocalPosition: {x: 0, y: 0, z: -50}
+  m_LocalScale: {x: 10, y: 10, z: 10}
+  m_Children: []
+  m_Father: {fileID: 1951022366}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 90}
+--- !u!64 &304001791
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 304001789}
+  m_Material: {fileID: 13400000, guid: 8a710917d45110747b42a848bb68ad96, type: 2}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &304001792
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 304001789}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 70a4e4c187842a648a6caf214821693a, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &304001793
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 304001789}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &629075318
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 629075320}
+  - component: {fileID: 629075319}
+  m_Layer: 0
+  m_Name: Controller
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &629075319
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 629075318}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db5bbdd04d092d94e83a98f5060c40ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  BoundX: 50
+  BoundY: 50
+  BoundZ: 50
+  SphereCount: 500
+  SpherePrefab: {fileID: 4767608665189895813, guid: c68c24bb11a07d545bae13bdd791bedb, type: 3}
+  UnitySpherePrefab: {fileID: 7799255399773132221, guid: c839b933d1b54ac4580074a75f78a7a5, type: 3}
+  Speed: 400
+  UsingUnity: 0
+  UsingBruteForce: 0
+--- !u!4 &629075320
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 629075318}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &693549749
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 693549750}
+  - component: {fileID: 693549753}
+  - component: {fileID: 693549752}
+  - component: {fileID: 693549751}
+  m_Layer: 0
+  m_Name: Wall
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &693549750
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 693549749}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 50, y: 0, z: 0}
+  m_LocalScale: {x: 10, y: 10, z: 10}
+  m_Children: []
+  m_Father: {fileID: 1951022366}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+--- !u!64 &693549751
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 693549749}
+  m_Material: {fileID: 13400000, guid: 8a710917d45110747b42a848bb68ad96, type: 2}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &693549752
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 693549749}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 70a4e4c187842a648a6caf214821693a, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &693549753
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 693549749}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &738326826
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 738326827}
+  - component: {fileID: 738326830}
+  - component: {fileID: 738326829}
+  - component: {fileID: 738326828}
+  m_Layer: 0
+  m_Name: Floor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &738326827
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 738326826}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -50, z: 0}
+  m_LocalScale: {x: 10, y: 10, z: 10}
+  m_Children: []
+  m_Father: {fileID: 1951022366}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!64 &738326828
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 738326826}
+  m_Material: {fileID: 13400000, guid: 8a710917d45110747b42a848bb68ad96, type: 2}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &738326829
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 738326826}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 70a4e4c187842a648a6caf214821693a, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &738326830
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 738326826}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1752100763
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1752100764}
+  - component: {fileID: 1752100767}
+  - component: {fileID: 1752100766}
+  - component: {fileID: 1752100765}
+  m_Layer: 0
+  m_Name: Cieling
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1752100764
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1752100763}
+  m_LocalRotation: {x: 0, y: 0, z: 1, w: 0}
+  m_LocalPosition: {x: 0, y: 50, z: 0}
+  m_LocalScale: {x: 10, y: 10, z: 10}
+  m_Children: []
+  m_Father: {fileID: 1951022366}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 180}
+--- !u!64 &1752100765
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1752100763}
+  m_Material: {fileID: 13400000, guid: 8a710917d45110747b42a848bb68ad96, type: 2}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1752100766
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1752100763}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 70a4e4c187842a648a6caf214821693a, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1752100767
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1752100763}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1771523384
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1771523386}
+  - component: {fileID: 1771523385}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1771523385
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1771523384}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1771523386
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1771523384}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1951022365
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1951022366}
+  m_Layer: 0
+  m_Name: Walls
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1951022366
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1951022365}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 738326827}
+  - {fileID: 1752100764}
+  - {fileID: 113888555}
+  - {fileID: 693549750}
+  - {fileID: 48431403}
+  - {fileID: 304001790}
+  - {fileID: 2113308770}
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2113308769
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2113308770}
+  - component: {fileID: 2113308773}
+  - component: {fileID: 2113308772}
+  - component: {fileID: 2113308771}
+  m_Layer: 0
+  m_Name: Thick Floor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2113308770
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2113308769}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -100, z: 0}
+  m_LocalScale: {x: 100, y: 100, z: 100}
+  m_Children: []
+  m_Father: {fileID: 1951022366}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &2113308771
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2113308769}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &2113308772
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2113308769}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &2113308773
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2113308769}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}

--- a/Assets/Scenes/3D/3D Explosion.unity.meta
+++ b/Assets/Scenes/3D/3D Explosion.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3489a1447ac542441ae7f4ccf9c0a800
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/3D/Collisions.cs
+++ b/Assets/Scripts/3D/Collisions.cs
@@ -19,16 +19,24 @@ namespace ThreeDimensions {
 
         [SerializeField]
         private bool UsingUnity, UsingBruteForce;
+        private Octree Tree;
+        
         private void Start()
         {
             Spheres = new List<Sphere>();
             for (int i = 0; i < SphereCount; i++)
             {
-                Spheres.Add(Instantiate(UsingUnity ? UnitySpherePrefab : SpherePrefab, new Vector3(Random.Range(-BoundX, BoundX), Random.Range(-BoundY, BoundY), Random.Range(-BoundZ, BoundZ)), Quaternion.identity).GetComponent<Sphere>());
+                float rad = 2.5f; // determine radius
+                Spheres.Add(Instantiate(UsingUnity ? UnitySpherePrefab : SpherePrefab, new Vector3(Random.Range(-BoundX + rad, BoundX - rad), Random.Range(-BoundY + rad, BoundY - rad), Random.Range(-BoundZ + rad, BoundZ - rad)), Quaternion.identity).GetComponent<Sphere>());
                 Spheres[i].GetComponent<Rigidbody>().AddForce(new Vector3(Random.Range(-1f, 1f), Random.Range(-1f, 1f), Random.Range(-1f, 1)).normalized * Speed);
                 Spheres[i].name = "Sphere " + i;
                 Spheres[i].SetRadius(Spheres[i].transform.localScale.x / 2);
                 Spheres[i].SetMass(Spheres[i].GetComponent<Rigidbody>().mass);
+            }
+
+            if (!UsingBruteForce && !UsingUnity) {
+                Tree = new Octree(Spheres, BoundX*2, BoundY*2, BoundZ*2);
+                Tree.BuildOctree();
             }
         }
 
@@ -83,12 +91,13 @@ namespace ThreeDimensions {
                 // Octree
                 else
                 {
-                    Octree o = new Octree(Spheres, BoundX*2, BoundY*2, BoundZ*2);
-                    o.BuildOctree();
+                    // Octree o = new Octree(Spheres, BoundX*2, BoundY*2, BoundZ*2);
+                    // o.BuildOctree();
+                    Tree.UpdateTree();
 
                     for (int s1 = 0; s1 < Spheres.Count; s1++)
                     {
-                        List<Sphere> spheresToCheck = o.Query(Spheres[s1]);
+                        List<Sphere> spheresToCheck = Tree.Query(Spheres[s1]);
                         for (int s2 = 0; s2 < spheresToCheck.Count; s2++)
                         {
                             if (Spheres[s1] != spheresToCheck[s2] && Spheres[s1].IsColliding(spheresToCheck[s2]))

--- a/Assets/Scripts/3D/Explosion.cs
+++ b/Assets/Scripts/3D/Explosion.cs
@@ -28,7 +28,6 @@ namespace ThreeDimensions
             for (int i = 0; i < SphereCount; i++)
             {
                 float rad = Random.Range(0.5f, 5f); // determine radius
-                //float rad = 1f;
                 Spheres.Add(Instantiate(UsingUnity ? UnitySpherePrefab : SpherePrefab, Vector3.zero, Quaternion.identity).GetComponent<Sphere>());
                 Spheres[i].GetComponent<Rigidbody>().AddForce(new Vector3(Random.Range(-1f, 1f), Random.Range(-1f, 1f), Random.Range(-1f, 1)).normalized * Speed);
                 Spheres[i].transform.localScale = new Vector3(rad, rad, rad);
@@ -43,29 +42,6 @@ namespace ThreeDimensions
                 Tree.BuildOctree();
             }
         }
-
-        // distribution algorithm from https://stackoverflow.com/questions/9600801/evenly-distributing-n-points-on-a-sphere
-        //private Vector3[] FindPointsOnSphere(float radius, int sphereCount)
-        //{
-        //    Vector3[] pts = new Vector3[sphereCount];
-        //    float phi = Mathf.PI * (3f - Mathf.Sqrt(5f));
-
-        //    for (int i = 0; i < sphereCount; i++)
-        //    {
-        //        float y = 1 - (i / (sphereCount - 1)) * 2;
-        //        radius = Mathf.Sqrt(1 - y * y);
-
-        //        float theta = phi * i;
-
-        //        float x = 100f;
-        //        float z = Mathf.Sin(theta) * radius;
-
-        //        pts[i] = new Vector3(x, y, z);
-        //    }
-
-        //    return pts;
-        //}
-
 
         private void Update()
         {
@@ -118,8 +94,6 @@ namespace ThreeDimensions
                 // Octree
                 else
                 {
-                    // Octree o = new Octree(Spheres, BoundX*2, BoundY*2, BoundZ*2);
-                    // o.BuildOctree();
                     Tree.UpdateTree();
 
                     for (int s1 = 0; s1 < Spheres.Count; s1++)

--- a/Assets/Scripts/3D/Explosion.cs
+++ b/Assets/Scripts/3D/Explosion.cs
@@ -1,0 +1,178 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ThreeDimensions
+{
+    public class Explosion : MonoBehaviour
+    {
+        private List<Sphere> Spheres;
+
+        [SerializeField]
+        private float BoundX, BoundY, BoundZ;
+        [Range(0, 1000000), SerializeField]
+        private int SphereCount;
+        [SerializeField]
+        private GameObject SpherePrefab, UnitySpherePrefab;
+        [Range(0, 1000), SerializeField]
+        private float Speed;
+
+        [SerializeField]
+        private bool UsingUnity, UsingBruteForce;
+        private Octree Tree;
+
+        private void Start()
+        {
+            Spheres = new List<Sphere>();
+
+            for (int i = 0; i < SphereCount; i++)
+            {
+                float rad = Random.Range(0.5f, 5f); // determine radius
+                //float rad = 1f;
+                Spheres.Add(Instantiate(UsingUnity ? UnitySpherePrefab : SpherePrefab, Vector3.zero, Quaternion.identity).GetComponent<Sphere>());
+                Spheres[i].GetComponent<Rigidbody>().AddForce(new Vector3(Random.Range(-1f, 1f), Random.Range(-1f, 1f), Random.Range(-1f, 1)).normalized * Speed);
+                Spheres[i].transform.localScale = new Vector3(rad, rad, rad);
+                Spheres[i].name = "Sphere " + i;
+                Spheres[i].SetRadius(Spheres[i].transform.localScale.x / 2);
+                Spheres[i].SetMass(Spheres[i].GetComponent<Rigidbody>().mass);
+            }
+
+            if (!UsingBruteForce && !UsingUnity)
+            {
+                Tree = new Octree(Spheres, BoundX * 2, BoundY * 2, BoundZ * 2);
+                Tree.BuildOctree();
+            }
+        }
+
+        // distribution algorithm from https://stackoverflow.com/questions/9600801/evenly-distributing-n-points-on-a-sphere
+        //private Vector3[] FindPointsOnSphere(float radius, int sphereCount)
+        //{
+        //    Vector3[] pts = new Vector3[sphereCount];
+        //    float phi = Mathf.PI * (3f - Mathf.Sqrt(5f));
+
+        //    for (int i = 0; i < sphereCount; i++)
+        //    {
+        //        float y = 1 - (i / (sphereCount - 1)) * 2;
+        //        radius = Mathf.Sqrt(1 - y * y);
+
+        //        float theta = phi * i;
+
+        //        float x = 100f;
+        //        float z = Mathf.Sin(theta) * radius;
+
+        //        pts[i] = new Vector3(x, y, z);
+        //    }
+
+        //    return pts;
+        //}
+
+
+        private void Update()
+        {
+            if (!UsingUnity)
+            {
+                // Brute Force
+                if (UsingBruteForce)
+                {
+                    for (int s1 = 0; s1 < Spheres.Count - 1; s1++)
+                    {
+                        for (int s2 = s1 + 1; s2 < Spheres.Count; s2++)
+                        {
+                            if (Spheres[s1].IsColliding(Spheres[s2]))
+                            {
+                                Vector3 dir = Spheres[s2].transform.position - Spheres[s1].transform.position;
+                                if (Vector3.Angle(dir, Spheres[s1].GetComponent<Rigidbody>().velocity) > 180)
+                                {
+                                    //Debug.Log("SKIPPED");
+                                    continue;
+                                }
+
+                                //Debug.Log("HERE");
+                                //elastic collision 
+                                float invMassSum = Spheres[s1].GetMass() + Spheres[s2].GetMass();
+                                invMassSum = 1 / invMassSum;
+
+                                float m1Dif = Spheres[s1].GetMass() - Spheres[s2].GetMass();
+                                float m2Dif = -m1Dif;
+
+                                Vector3 vel1 = Spheres[s1].GetComponent<Rigidbody>().velocity;
+                                Vector3 vel2 = Spheres[s2].GetComponent<Rigidbody>().velocity;
+
+                                Vector3 newVel1 = (vel1 * m1Dif * invMassSum) + (vel2 * 2 * Spheres[s2].GetMass() * invMassSum);
+                                Vector3 newVel2 = (vel1 * 2 * Spheres[s1].GetMass() * invMassSum) + (vel2 * m2Dif * invMassSum);
+
+                                Spheres[s1].GetComponent<Rigidbody>().velocity = newVel1;
+                                Spheres[s2].GetComponent<Rigidbody>().velocity = newVel2;
+
+                                //make sure they are not intersecting
+                                Vector3 centerDir = Spheres[s2].transform.position - Spheres[s1].transform.position;
+                                float overLapMag = (Spheres[s1].GetRadius() + Spheres[s2].GetRadius()) - centerDir.magnitude;
+                                centerDir.Normalize();
+
+                                Spheres[s1].transform.position = Spheres[s1].transform.position - centerDir * overLapMag / 2f;
+                                Spheres[s2].transform.position = Spheres[s2].transform.position + centerDir * overLapMag / 2f;
+                            }
+                        }
+                    }
+                }
+                // Octree
+                else
+                {
+                    // Octree o = new Octree(Spheres, BoundX*2, BoundY*2, BoundZ*2);
+                    // o.BuildOctree();
+                    Tree.UpdateTree();
+
+                    for (int s1 = 0; s1 < Spheres.Count; s1++)
+                    {
+                        List<Sphere> spheresToCheck = Tree.Query(Spheres[s1]);
+                        for (int s2 = 0; s2 < spheresToCheck.Count; s2++)
+                        {
+                            if (Spheres[s1] != spheresToCheck[s2] && Spheres[s1].IsColliding(spheresToCheck[s2]))
+                            {
+                                Vector3 dir = spheresToCheck[s2].transform.position - Spheres[s1].transform.position;
+                                if (Vector3.Angle(dir, Spheres[s1].GetComponent<Rigidbody>().velocity) > 180)
+                                {
+                                    continue;
+                                }
+
+                                //elastic collision 
+                                float invMassSum = Spheres[s1].GetMass() + spheresToCheck[s2].GetMass();
+                                invMassSum = 1 / invMassSum;
+
+                                float m1Dif = Spheres[s1].GetMass() - spheresToCheck[s2].GetMass();
+                                float m2Dif = -m1Dif;
+
+                                Vector3 vel1 = Spheres[s1].GetComponent<Rigidbody>().velocity;
+                                Vector3 vel2 = spheresToCheck[s2].GetComponent<Rigidbody>().velocity;
+
+                                Vector3 newVel1 = (vel1 * m1Dif * invMassSum) + (vel2 * 2 * spheresToCheck[s2].GetMass() * invMassSum);
+                                Vector3 newVel2 = (vel1 * 2 * Spheres[s1].GetMass() * invMassSum) + (vel2 * m2Dif * invMassSum);
+
+                                Spheres[s1].GetComponent<Rigidbody>().velocity = newVel1;
+                                spheresToCheck[s2].GetComponent<Rigidbody>().velocity = newVel2;
+
+                                //make sure they are not intersecting
+                                Vector3 centerDir = spheresToCheck[s2].transform.position - Spheres[s1].transform.position;
+                                float overLapMag = (Spheres[s1].GetRadius() + spheresToCheck[s2].GetRadius()) - centerDir.magnitude;
+                                centerDir.Normalize();
+
+                                Spheres[s1].transform.position = Spheres[s1].transform.position - centerDir * overLapMag / 2f;
+                                spheresToCheck[s2].transform.position = spheresToCheck[s2].transform.position + centerDir * overLapMag / 2f;
+                            }
+                        }
+                    }
+                }
+            }
+            // Unity
+            else
+            {
+                foreach (Sphere s in Spheres)
+                {
+                    Vector3 vel = s.GetComponent<Rigidbody>().velocity;
+                    s.GetComponent<Rigidbody>().velocity = Vector3.zero;
+                    s.GetComponent<Rigidbody>().AddForce(vel.normalized * Speed);
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/3D/Explosion.cs.meta
+++ b/Assets/Scripts/3D/Explosion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db5bbdd04d092d94e83a98f5060c40ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/3D/Octree.cs
+++ b/Assets/Scripts/3D/Octree.cs
@@ -29,7 +29,7 @@ namespace ThreeDimensions
         private void BuildOctree(Node curNode)
         {
 
-            if (!(curNode.GetSpheres().Count < MinSpheres || curNode.GetXSize() < MinDimension || curNode.GetYSize() < MinDimension) || curNode.GetZSize() < MinDimension)
+            if (!(curNode.GetSpheres().Count < MinSpheres || curNode.GetXSize() < MinDimension || curNode.GetYSize() < MinDimension || curNode.GetZSize() < MinDimension))
             {
                 // creating empty children
                 for(int i = 0; i < 8; i++)
@@ -50,13 +50,13 @@ namespace ThreeDimensions
                     curNode.GetChildren()[index].AddSphere(s);
                 }
                 
-                int[] childNums = new int[8]; 
-                int j = 0;
+                // int[] childNums = new int[8]; 
+                // int j = 0;
                 // building the trees for the children
                 foreach(Node child in curNode.GetChildren()){
                     BuildOctree(child);
-                    childNums[j] = child.GetSpheres().Count;
-                    j++;
+                    // childNums[j] = child.GetSpheres().Count;
+                    // j++;
                 }
                 curNode.RemoveSpheres();
             }

--- a/Assets/Scripts/3D/Octree.cs
+++ b/Assets/Scripts/3D/Octree.cs
@@ -63,6 +63,110 @@ namespace ThreeDimensions
 
         }
 
+
+        public void UpdateTree()
+        {
+
+            UpdateTree(Root);
+
+            CleanNodes(Root);
+
+        }
+
+        private void UpdateTree(Node curNode)
+        {
+            if(curNode.GetSpheres().Count != 0)
+            {
+                List<Sphere> removed = new List<Sphere>();
+                foreach(Sphere s in curNode.GetSpheres())
+                {
+                    if(!curNode.Contains(s))
+                    {
+                        FindNode(s).AddSphere(s);
+                        removed.Add(s);
+                    }
+                }
+                
+                curNode.GetSpheres().RemoveAll((Sphere s) => removed.Contains(s));
+            }
+            else
+            {
+                foreach(Node child in curNode.GetChildren())
+                {
+                    UpdateTree(child);
+                }
+            }
+        }
+
+        private int CleanNodes(Node curNode)
+        {
+            //clean Children
+            int totalSpheres = 0;
+            foreach(Node child in curNode.GetChildren())
+            {
+                totalSpheres += CleanNodes(child);
+            }
+            // adding new children if node has too many nodes in the parent
+            if(totalSpheres > MinSpheres && curNode.GetChildren().Count == 0)
+            {
+                // creating empty children
+                for(int i = 0; i < 8; i++)
+                {
+                    curNode.AddChild(new Node(curNode.GetXSize()/2f, curNode.GetYSize()/2f, curNode.GetZSize()/2f,
+                                                                         curNode.GetX() + Mathf.Pow(-1, i+1) * curNode.GetXSize()/4f,
+                                                                         curNode.GetY() + Mathf.Pow(-1, i/2) * curNode.GetYSize()/4f,
+                                                                         curNode.GetZ() - Mathf.Pow(-1, i/4) * curNode.GetZSize()/4f, curNode));
+                }
+
+                // placing spheres into the correct child using centers only
+                foreach (Sphere s in curNode.GetSpheres()) 
+                {
+                    int dx = (s.transform.position.x > curNode.GetX()) ? 1 : 0;
+                    int dy = (s.transform.position.y > curNode.GetY()) ? 0 : 1;
+                    int dz = (s.transform.position.z > curNode.GetZ()) ? 1 : 0; 
+                    int index = dx + dy * 2 + dz * 4;
+                    curNode.GetChildren()[index].AddSphere(s);
+                }
+            }
+            // removing children if they can be all put in a single parent
+            if(totalSpheres < MinSpheres && curNode.GetChildren().Count != 0)
+            {
+                foreach(Node child in curNode.GetChildren())
+                {
+                    foreach(Sphere s in child.GetSpheres())
+                    {
+                        curNode.AddSphere(s);
+                    }
+                }
+                curNode.RemoveChildren();
+                totalSpheres = 0;
+            }
+            //check if too few and delete
+            return curNode.GetSpheres().Count + totalSpheres;
+        }
+        
+        private Node FindNode(Sphere s)
+        {
+            return FindNode(s, Root);
+        }
+        
+        private Node FindNode(Sphere s, Node curNode)
+        {
+            if(curNode.GetChildren().Count == 0)
+            {
+                return curNode;
+            }
+            foreach(Node child in curNode.GetChildren())
+            {
+                if(child.Contains(s))
+                {
+                    return FindNode(s, child);
+                }
+            }
+            Debug.LogError("RUT ROH " + s.name);
+            return null;
+        }
+
         // query(node n) : List
         //      check if the current nodes bounds overlap with the sphere
         //          if so, add the spheres in the node to the list of spheres found
@@ -92,6 +196,7 @@ namespace ThreeDimensions
             private List<Sphere> Spheres;
             private List<Node> Children;
             private Node Parent;
+
             private float XSize, YSize, ZSize;
             private float X, Y, Z;
 
@@ -99,6 +204,7 @@ namespace ThreeDimensions
             {
                 Spheres = new List<Sphere>();
                 Children = new List<Node>();
+ 
                 XSize = xSize;
                 YSize = ySize;
                 ZSize = zSize;
@@ -117,6 +223,23 @@ namespace ThreeDimensions
                 Spheres = spheres;
             }
 
+            public bool Contains(Sphere s)
+            {
+                if(s.transform.position.x < X - XSize/2f || s.transform.position.x > X + XSize/2f)
+                {
+                    return false;
+                }
+                if(s.transform.position.y < Y - YSize/2f || s.transform.position.y > Y + YSize/2f)
+                {
+                    return false;
+                }
+                if(s.transform.position.z < Z - ZSize/2f || s.transform.position.z > Z + ZSize/2f)
+                {
+                    return false;
+                }
+                return true;
+            }
+
             public void AddChild(Node child){
                 Children.Add(child);
             }
@@ -128,6 +251,11 @@ namespace ThreeDimensions
             public void RemoveSpheres() 
             {
                 Spheres.Clear();
+            }
+
+            public void RemoveChildren()
+            {
+                Children.Clear();
             }
 
             public List<Sphere> GetSpheres() 

--- a/Assets/Scripts/3D/Octree.cs
+++ b/Assets/Scripts/3D/Octree.cs
@@ -163,7 +163,7 @@ namespace ThreeDimensions
                     return FindNode(s, child);
                 }
             }
-            Debug.LogError("RUT ROH " + s.name);
+            Debug.LogWarning("RUT ROH " + s.name);
             return null;
         }
 


### PR DESCRIPTION
Rather than reconstructing the octree on every frame, this approach will now check the position of the spheres one each frame and redistribute them into the proper nodes of the octree before doing the collision detection.